### PR TITLE
[PLAT-1237] Return FeatureLineAttributes for SceneViewState

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -2047,6 +2047,25 @@ export interface Failure {
 /**
  *
  * @export
+ * @interface FeatureLines
+ */
+export interface FeatureLines {
+  /**
+   *
+   * @type {Color3}
+   * @memberof FeatureLines
+   */
+  color: Color3;
+  /**
+   *
+   * @type {number}
+   * @memberof FeatureLines
+   */
+  width: number;
+}
+/**
+ *
+ * @export
  * @interface FileList
  */
 export interface FileList {
@@ -4252,6 +4271,12 @@ export interface SceneViewStateDataAttributes {
    * @memberof SceneViewStateDataAttributes
    */
   thumbnails?: Array<ThumbnailData>;
+  /**
+   *
+   * @type {FeatureLines}
+   * @memberof SceneViewStateDataAttributes
+   */
+  featureLines?: FeatureLines;
 }
 /**
  *

--- a/client/version.ts
+++ b/client/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.17.0';
+export const version = '0.17.1';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertexvis/api-client-node",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "The Vertex REST API client for Node.js.",
   "license": "MIT",
   "author": "Vertex Developers <support@vertexvis.com> (https://developer.vertexvis.com)",

--- a/spec.yml
+++ b/spec.yml
@@ -8721,6 +8721,17 @@ components:
         - uri
         - width
       type: object
+    FeatureLines:
+      additionalProperties: false
+      properties:
+        color:
+          $ref: '#/components/schemas/Color3'
+        width:
+          type: number
+      required:
+        - color
+        - width
+      type: object
     ExportConfig:
       description: Describes the options for configuring a file export.
       discriminator:
@@ -10213,6 +10224,8 @@ components:
           items:
             $ref: '#/components/schemas/ThumbnailData'
           type: array
+        featureLines:
+          $ref: '#/components/schemas/FeatureLines'
       type: object
     SceneViewRelationship_data:
       properties:


### PR DESCRIPTION
## Summary
We want to return the FeatureLineAttributes for a given SceneViewState so that we can ensure we are using the correct feature line settings on story snapshots.

## Test Plan
Tested in connect-app

## Release Notes
None

## Possible Regressions
None

## Dependencies
None