### PR TITLE
[PLAT-2646] Support phantom state

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -1322,6 +1322,12 @@ export interface CreateSceneItemOverrideRequestDataAttributes {
    * @memberof CreateSceneItemOverrideRequestDataAttributes
    */
   selected?: ColorMaterial;
+  /**
+   * Phantom state of the item.
+   * @type {boolean}
+   * @memberof CreateSceneItemOverrideRequestDataAttributes
+   */
+  phantom?: boolean;
 }
 /**
  *
@@ -1393,7 +1399,13 @@ export interface CreateSceneItemRequestDataAttributes {
    */
   name?: string;
   /**
-   * ID provided for correlation. For example, an existing ID from a PLM system.
+   * A 0-based index used for defining a consistent ordering amongst sibling scene items.
+   * @type {number}
+   * @memberof CreateSceneItemRequestDataAttributes
+   */
+  ordinal?: number;
+  /**
+   * Optional ability to specify a parent scene item by scene item supplied ID. For example, an  existing ID from a PLM system. This approach is an alternative to providing a specific scene  item ID with the relationship parent property.
    * @type {string}
    * @memberof CreateSceneItemRequestDataAttributes
    */
@@ -1428,6 +1440,12 @@ export interface CreateSceneItemRequestDataAttributes {
    * @memberof CreateSceneItemRequestDataAttributes
    */
   visible?: boolean;
+  /**
+   * Phantom state of the item.
+   * @type {boolean}
+   * @memberof CreateSceneItemRequestDataAttributes
+   */
+  phantom?: boolean;
   /**
    * Additional metadata for the scene-item. This metadata will take precedence over any metadata that belongs to the part file.
    * @type {{ [key: string]: MetadataLongType | MetadataFloatType | MetadataDateType | MetadataStringType | MetadataNullType; }}
@@ -4085,6 +4103,12 @@ export interface SceneItemDataAttributes {
   name?: string;
   /**
    *
+   * @type {boolean}
+   * @memberof SceneItemDataAttributes
+   */
+  phantom?: boolean;
+  /**
+   *
    * @type {string}
    * @memberof SceneItemDataAttributes
    */
@@ -4241,6 +4265,12 @@ export interface SceneItemOverrideDataAttributes {
    * @memberof SceneItemOverrideDataAttributes
    */
   selected?: ColorMaterial;
+  /**
+   *
+   * @type {boolean}
+   * @memberof SceneItemOverrideDataAttributes
+   */
+  phantom?: boolean;
 }
 /**
  *
@@ -5242,6 +5272,12 @@ export interface UpdateSceneItemOverrideRequestDataAttributes {
    * @memberof UpdateSceneItemOverrideRequestDataAttributes
    */
   selected?: ColorMaterialNullable | null;
+  /**
+   *
+   * @type {boolean}
+   * @memberof UpdateSceneItemOverrideRequestDataAttributes
+   */
+  phantom?: boolean | null;
 }
 /**
  *
@@ -5330,6 +5366,12 @@ export interface UpdateSceneItemRequestDataAttributes {
       | MetadataStringType
       | MetadataNullType;
   };
+  /**
+   * Phantom state of the item.
+   * @type {boolean}
+   * @memberof UpdateSceneItemRequestDataAttributes
+   */
+  phantom?: boolean;
 }
 /**
  *

--- a/client/version.ts
+++ b/client/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.20.9';
+export const version = '0.20.10';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertexvis/api-client-node",
-  "version": "0.20.9",
+  "version": "0.20.10",
   "description": "The Vertex REST API client for Node.js.",
   "license": "MIT",
   "author": "Vertex Developers <support@vertexvis.com> (https://developer.vertexvis.com)",

--- a/spec.yml
+++ b/spec.yml
@@ -9680,6 +9680,9 @@ components:
           $ref: '#/components/schemas/ColorMaterialNullable'
         selected:
           $ref: '#/components/schemas/ColorMaterialNullable'
+        phantom:
+          nullable: true
+          type: boolean
       type: object
     UpdateSceneItemOverrideRequest_data:
       properties:
@@ -9713,6 +9716,9 @@ components:
           $ref: '#/components/schemas/ColorMaterial'
         selected:
           $ref: '#/components/schemas/ColorMaterial'
+        phantom:
+          description: Phantom state of the item.
+          type: boolean
       type: object
     CreateSceneItemOverrideRequest_data_relationships:
       properties:
@@ -9770,6 +9776,9 @@ components:
           description: |
             Additional metadata for the scene-item. This metadata will take precedence over any metadata that belongs to the part file.
           type: object
+        phantom:
+          description: Phantom state of the item.
+          type: boolean
       type: object
     UpdateSceneItemRequest_data_relationships:
       properties:
@@ -10356,6 +10365,8 @@ components:
           maxLength: 1024
           minLength: 1
           type: string
+        phantom:
+          type: boolean
         suppliedId:
           example: some-string
           maxLength: 1024
@@ -10503,6 +10514,8 @@ components:
           $ref: '#/components/schemas/ColorMaterial'
         selected:
           $ref: '#/components/schemas/ColorMaterial'
+        phantom:
+          type: boolean
       required:
         - created
       type: object
@@ -10544,10 +10557,14 @@ components:
           maxLength: 1024
           minLength: 1
           type: string
-        parent:
+        ordinal:
           description:
-            ID provided for correlation. For example, an existing ID from
-            a PLM system.
+            A 0-based index used for defining a consistent ordering amongst
+            sibling scene items.
+          type: integer
+        parent:
+          description: |
+            Optional ability to specify a parent scene item by scene item supplied ID. For example, an  existing ID from a PLM system. This approach is an alternative to providing a specific scene  item ID with the relationship parent property.
           example: PN12345
           maxLength: 1024
           type: string
@@ -10571,6 +10588,9 @@ components:
         visible:
           description: Item visibility.
           example: true
+          type: boolean
+        phantom:
+          description: Phantom state of the item.
           type: boolean
         metadata:
           additionalProperties:


### PR DESCRIPTION
## Summary
Updates vertex-api-client-node to include the latest vertex-api changes, particularly support for a phantom state on scene items, scene item overrides, and scene view state overrides.