### PR TITLE
[PLAT-3025] Retire selection material

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -1318,10 +1318,10 @@ export interface CreateSceneItemOverrideRequestDataAttributes {
   material?: ColorMaterial;
   /**
    *
-   * @type {ColorMaterial}
+   * @type {boolean}
    * @memberof CreateSceneItemOverrideRequestDataAttributes
    */
-  selected?: ColorMaterial;
+  selected?: boolean;
   /**
    * Phantom state of the item.
    * @type {boolean}
@@ -4261,10 +4261,10 @@ export interface SceneItemOverrideDataAttributes {
   material?: ColorMaterial;
   /**
    *
-   * @type {ColorMaterial}
+   * @type {boolean}
    * @memberof SceneItemOverrideDataAttributes
    */
-  selected?: ColorMaterial;
+  selected?: boolean;
   /**
    *
    * @type {boolean}
@@ -5268,10 +5268,10 @@ export interface UpdateSceneItemOverrideRequestDataAttributes {
   material?: ColorMaterialNullable | null;
   /**
    *
-   * @type {ColorMaterialNullable}
+   * @type {boolean}
    * @memberof UpdateSceneItemOverrideRequestDataAttributes
    */
-  selected?: ColorMaterialNullable | null;
+  selected?: boolean | null;
   /**
    *
    * @type {boolean}

--- a/client/version.ts
+++ b/client/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.21.0';
+export const version = '0.21.1';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertexvis/api-client-node",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "The Vertex REST API client for Node.js.",
   "license": "MIT",
   "author": "Vertex Developers <support@vertexvis.com> (https://developer.vertexvis.com)",

--- a/spec.yml
+++ b/spec.yml
@@ -9679,7 +9679,8 @@ components:
         material:
           $ref: '#/components/schemas/ColorMaterialNullable'
         selected:
-          $ref: '#/components/schemas/ColorMaterialNullable'
+          nullable: true
+          type: boolean
         phantom:
           nullable: true
           type: boolean
@@ -9715,7 +9716,7 @@ components:
         material:
           $ref: '#/components/schemas/ColorMaterial'
         selected:
-          $ref: '#/components/schemas/ColorMaterial'
+          type: boolean
         phantom:
           description: Phantom state of the item.
           type: boolean
@@ -10513,7 +10514,7 @@ components:
         material:
           $ref: '#/components/schemas/ColorMaterial'
         selected:
-          $ref: '#/components/schemas/ColorMaterial'
+          type: boolean
         phantom:
           type: boolean
       required:


### PR DESCRIPTION
## Summary
Updates vertex-api-client-node to include the latest vertex-api changes, specifically converting _selected_ in SceneItemOverride from a color material to a boolean.