### PR TITLE
[PLAT-3104] Support end items

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -1328,6 +1328,12 @@ export interface CreateSceneItemOverrideRequestDataAttributes {
    * @memberof CreateSceneItemOverrideRequestDataAttributes
    */
   phantom?: boolean;
+  /**
+   * Whether this item is an end item.
+   * @type {boolean}
+   * @memberof CreateSceneItemOverrideRequestDataAttributes
+   */
+  endItem?: boolean;
 }
 /**
  *
@@ -1446,6 +1452,12 @@ export interface CreateSceneItemRequestDataAttributes {
    * @memberof CreateSceneItemRequestDataAttributes
    */
   phantom?: boolean;
+  /**
+   * Whether this item is an end item.
+   * @type {boolean}
+   * @memberof CreateSceneItemRequestDataAttributes
+   */
+  endItem?: boolean;
   /**
    * Additional metadata for the scene-item. This metadata will take precedence over any metadata that belongs to the part file.
    * @type {{ [key: string]: MetadataLongType | MetadataFloatType | MetadataDateType | MetadataStringType | MetadataNullType; }}
@@ -4078,6 +4090,12 @@ export interface SceneItemDataAttributes {
   created?: string;
   /**
    *
+   * @type {boolean}
+   * @memberof SceneItemDataAttributes
+   */
+  endItem?: boolean;
+  /**
+   *
    * @type {ColorMaterial}
    * @memberof SceneItemDataAttributes
    */
@@ -4271,6 +4289,12 @@ export interface SceneItemOverrideDataAttributes {
    * @memberof SceneItemOverrideDataAttributes
    */
   phantom?: boolean;
+  /**
+   *
+   * @type {boolean}
+   * @memberof SceneItemOverrideDataAttributes
+   */
+  endItem?: boolean;
 }
 /**
  *
@@ -5278,6 +5302,12 @@ export interface UpdateSceneItemOverrideRequestDataAttributes {
    * @memberof UpdateSceneItemOverrideRequestDataAttributes
    */
   phantom?: boolean | null;
+  /**
+   *
+   * @type {boolean}
+   * @memberof UpdateSceneItemOverrideRequestDataAttributes
+   */
+  endItem?: boolean | null;
 }
 /**
  *
@@ -5372,6 +5402,12 @@ export interface UpdateSceneItemRequestDataAttributes {
    * @memberof UpdateSceneItemRequestDataAttributes
    */
   phantom?: boolean;
+  /**
+   * Whether this item is an end item.
+   * @type {boolean}
+   * @memberof UpdateSceneItemRequestDataAttributes
+   */
+  endItem?: boolean;
 }
 /**
  *

--- a/client/version.ts
+++ b/client/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.21.1';
+export const version = '0.21.2';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertexvis/api-client-node",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "The Vertex REST API client for Node.js.",
   "license": "MIT",
   "author": "Vertex Developers <support@vertexvis.com> (https://developer.vertexvis.com)",

--- a/spec.yml
+++ b/spec.yml
@@ -9684,6 +9684,9 @@ components:
         phantom:
           nullable: true
           type: boolean
+        endItem:
+          nullable: true
+          type: boolean
       type: object
     UpdateSceneItemOverrideRequest_data:
       properties:
@@ -9719,6 +9722,9 @@ components:
           type: boolean
         phantom:
           description: Phantom state of the item.
+          type: boolean
+        endItem:
+          description: Whether this item is an end item.
           type: boolean
       type: object
     CreateSceneItemOverrideRequest_data_relationships:
@@ -9779,6 +9785,9 @@ components:
           type: object
         phantom:
           description: Phantom state of the item.
+          type: boolean
+        endItem:
+          description: Whether this item is an end item.
           type: boolean
       type: object
     UpdateSceneItemRequest_data_relationships:
@@ -10350,6 +10359,8 @@ components:
           example: 2020-01-01T12:00:00Z
           format: date-time
           type: string
+        endItem:
+          type: boolean
         materialOverride:
           $ref: '#/components/schemas/ColorMaterial'
         metadata:
@@ -10517,6 +10528,8 @@ components:
           type: boolean
         phantom:
           type: boolean
+        endItem:
+          type: boolean
       required:
         - created
       type: object
@@ -10592,6 +10605,9 @@ components:
           type: boolean
         phantom:
           description: Phantom state of the item.
+          type: boolean
+        endItem:
+          description: Whether this item is an end item.
           type: boolean
         metadata:
           additionalProperties:


### PR DESCRIPTION
## Summary
Updates vertex-api-client-node to include the latest vertex-api changes, particularly support for an end item state on scene items, scene item overrides, and scene view state overrides.