### PR TITLE
PLAT-3221: Add ReadStream input to support large file uploads

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -16716,7 +16716,7 @@ export const ScenesApiAxiosParamCreator = function (
      * @param {number} [pageSize] The number of items to return.
      * @param {string} [filterName] Comma-separated list of names to filter on.
      * @param {string} [filterSuppliedId] Comma-separated list of supplied IDs to filter on.
-     * @param {string} [fieldsScene] Comma-separated list of fields to return in response. An empty value returns no fields. &#x60;sceneItemCount&#x60; and &#x60;metadata&#x60; are only returned if explicitly requested.
+     * @param {string} [fieldsScene] Comma-separated list of fields to return in response. An empty value returns no fields. &#x60;metadata&#x60; is only returned if explicitly requested.
      * @param {{ [key: string]: string; }} [filterMetadata] Filter scenes that contain all the given metadata key-value pairs. Should be specified in query parameter map notation: &#x60;filter[metadata][key1]&#x3D;value1&amp;filter[metadata][key]&#x3D;value2&#x60;.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -17036,7 +17036,7 @@ export const ScenesApiFp = function (configuration?: Configuration) {
      * @param {number} [pageSize] The number of items to return.
      * @param {string} [filterName] Comma-separated list of names to filter on.
      * @param {string} [filterSuppliedId] Comma-separated list of supplied IDs to filter on.
-     * @param {string} [fieldsScene] Comma-separated list of fields to return in response. An empty value returns no fields. &#x60;sceneItemCount&#x60; and &#x60;metadata&#x60; are only returned if explicitly requested.
+     * @param {string} [fieldsScene] Comma-separated list of fields to return in response. An empty value returns no fields. &#x60;metadata&#x60; is only returned if explicitly requested.
      * @param {{ [key: string]: string; }} [filterMetadata] Filter scenes that contain all the given metadata key-value pairs. Should be specified in query parameter map notation: &#x60;filter[metadata][key1]&#x3D;value1&amp;filter[metadata][key]&#x3D;value2&#x60;.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -17195,7 +17195,7 @@ export const ScenesApiFactory = function (
      * @param {number} [pageSize] The number of items to return.
      * @param {string} [filterName] Comma-separated list of names to filter on.
      * @param {string} [filterSuppliedId] Comma-separated list of supplied IDs to filter on.
-     * @param {string} [fieldsScene] Comma-separated list of fields to return in response. An empty value returns no fields. &#x60;sceneItemCount&#x60; and &#x60;metadata&#x60; are only returned if explicitly requested.
+     * @param {string} [fieldsScene] Comma-separated list of fields to return in response. An empty value returns no fields. &#x60;metadata&#x60; is only returned if explicitly requested.
      * @param {{ [key: string]: string; }} [filterMetadata] Filter scenes that contain all the given metadata key-value pairs. Should be specified in query parameter map notation: &#x60;filter[metadata][key1]&#x3D;value1&amp;filter[metadata][key]&#x3D;value2&#x60;.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -17356,7 +17356,7 @@ export interface ScenesApiGetScenesRequest {
   readonly filterSuppliedId?: string;
 
   /**
-   * Comma-separated list of fields to return in response. An empty value returns no fields. &#x60;sceneItemCount&#x60; and &#x60;metadata&#x60; are only returned if explicitly requested.
+   * Comma-separated list of fields to return in response. An empty value returns no fields. &#x60;metadata&#x60; is only returned if explicitly requested.
    * @type {string}
    * @memberof ScenesApiGetScenes
    */
@@ -18152,9 +18152,10 @@ export const TranslationInspectionsApiAxiosParamCreator = function (
       };
     },
     /**
-     * Get a `queued-translation`. The response is either the status if `running` or `error` or, upon completion, redirects to the created `part-revision`. Once created, create scenes via the createScene API. For details, see our [Render static scenes](https://developer.vertexvis.com/docs/guides/render-static-scenes) guide.
+     * This has been deprecated and replaced by **queued-translation-jobs/{id}** - Get a `queued-translation`. The response is either the status if `running` or `error` or, upon completion, redirects to the created `part-revision`. Once created, create scenes via the createScene API. For details, see our [Render static scenes](https://developer.vertexvis.com/docs/guides/render-static-scenes) guide.
      * @param {string} id The &#x60;queued-translation&#x60; ID.
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     getQueuedTranslation: async (
@@ -18258,11 +18259,76 @@ export const TranslationInspectionsApiAxiosParamCreator = function (
       };
     },
     /**
-     * Get `queued-translation`s.
+     * Get all current translation jobs in progress.
      * @param {string} [pageCursor] The cursor for the next page of items.
      * @param {number} [pageSize] The number of items to return.
      * @param {string} [filterStatus] Status to filter on.
      * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    getQueuedTranslationJobs: async (
+      pageCursor?: string,
+      pageSize?: number,
+      filterStatus?: string,
+      options: AxiosRequestConfig = {}
+    ): Promise<RequestArgs> => {
+      const localVarPath = `/queued-translation-jobs`;
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
+
+      const localVarRequestOptions = {
+        method: 'GET',
+        ...baseOptions,
+        ...options,
+      };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
+
+      // authentication OAuth2 required
+      // oauth required
+      await setOAuthToObject(
+        localVarHeaderParameter,
+        'OAuth2',
+        [],
+        configuration
+      );
+
+      if (pageCursor !== undefined) {
+        localVarQueryParameter['page[cursor]'] = pageCursor;
+      }
+
+      if (pageSize !== undefined) {
+        localVarQueryParameter['page[size]'] = pageSize;
+      }
+
+      if (filterStatus !== undefined) {
+        localVarQueryParameter['filter[status]'] = filterStatus;
+      }
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions?.headers ?? {};
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      };
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
+    /**
+     * This has been deprecated and replaced by **queued-translation-jobs** - Get `queued-translation`s.
+     * @param {string} [pageCursor] The cursor for the next page of items.
+     * @param {number} [pageSize] The number of items to return.
+     * @param {string} [filterStatus] Status to filter on.
+     * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     getQueuedTranslations: async (
@@ -18386,9 +18452,10 @@ export const TranslationInspectionsApiFp = function (
       );
     },
     /**
-     * Get a `queued-translation`. The response is either the status if `running` or `error` or, upon completion, redirects to the created `part-revision`. Once created, create scenes via the createScene API. For details, see our [Render static scenes](https://developer.vertexvis.com/docs/guides/render-static-scenes) guide.
+     * This has been deprecated and replaced by **queued-translation-jobs/{id}** - Get a `queued-translation`. The response is either the status if `running` or `error` or, upon completion, redirects to the created `part-revision`. Once created, create scenes via the createScene API. For details, see our [Render static scenes](https://developer.vertexvis.com/docs/guides/render-static-scenes) guide.
      * @param {string} id The &#x60;queued-translation&#x60; ID.
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     async getQueuedTranslation(
@@ -18431,11 +18498,42 @@ export const TranslationInspectionsApiFp = function (
       );
     },
     /**
-     * Get `queued-translation`s.
+     * Get all current translation jobs in progress.
      * @param {string} [pageCursor] The cursor for the next page of items.
      * @param {number} [pageSize] The number of items to return.
      * @param {string} [filterStatus] Status to filter on.
      * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async getQueuedTranslationJobs(
+      pageCursor?: string,
+      pageSize?: number,
+      filterStatus?: string,
+      options?: AxiosRequestConfig
+    ): Promise<
+      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<QueuedJobList>
+    > {
+      const localVarAxiosArgs =
+        await localVarAxiosParamCreator.getQueuedTranslationJobs(
+          pageCursor,
+          pageSize,
+          filterStatus,
+          options
+        );
+      return createRequestFunction(
+        localVarAxiosArgs,
+        globalAxios,
+        BASE_PATH,
+        configuration
+      );
+    },
+    /**
+     * This has been deprecated and replaced by **queued-translation-jobs** - Get `queued-translation`s.
+     * @param {string} [pageCursor] The cursor for the next page of items.
+     * @param {number} [pageSize] The number of items to return.
+     * @param {string} [filterStatus] Status to filter on.
+     * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     async getQueuedTranslations(
@@ -18506,9 +18604,10 @@ export const TranslationInspectionsApiFactory = function (
         .then((request) => request(axios, basePath));
     },
     /**
-     * Get a `queued-translation`. The response is either the status if `running` or `error` or, upon completion, redirects to the created `part-revision`. Once created, create scenes via the createScene API. For details, see our [Render static scenes](https://developer.vertexvis.com/docs/guides/render-static-scenes) guide.
+     * This has been deprecated and replaced by **queued-translation-jobs/{id}** - Get a `queued-translation`. The response is either the status if `running` or `error` or, upon completion, redirects to the created `part-revision`. Once created, create scenes via the createScene API. For details, see our [Render static scenes](https://developer.vertexvis.com/docs/guides/render-static-scenes) guide.
      * @param {string} id The &#x60;queued-translation&#x60; ID.
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     getQueuedTranslation(id: string, options?: any): AxiosPromise<QueuedJob> {
@@ -18531,11 +18630,30 @@ export const TranslationInspectionsApiFactory = function (
         .then((request) => request(axios, basePath));
     },
     /**
-     * Get `queued-translation`s.
+     * Get all current translation jobs in progress.
      * @param {string} [pageCursor] The cursor for the next page of items.
      * @param {number} [pageSize] The number of items to return.
      * @param {string} [filterStatus] Status to filter on.
      * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    getQueuedTranslationJobs(
+      pageCursor?: string,
+      pageSize?: number,
+      filterStatus?: string,
+      options?: any
+    ): AxiosPromise<QueuedJobList> {
+      return localVarFp
+        .getQueuedTranslationJobs(pageCursor, pageSize, filterStatus, options)
+        .then((request) => request(axios, basePath));
+    },
+    /**
+     * This has been deprecated and replaced by **queued-translation-jobs** - Get `queued-translation`s.
+     * @param {string} [pageCursor] The cursor for the next page of items.
+     * @param {number} [pageSize] The number of items to return.
+     * @param {string} [filterStatus] Status to filter on.
+     * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     getQueuedTranslations(
@@ -18605,6 +18723,34 @@ export interface TranslationInspectionsApiGetQueuedTranslationJobRequest {
    * @memberof TranslationInspectionsApiGetQueuedTranslationJob
    */
   readonly id: string;
+}
+
+/**
+ * Request parameters for getQueuedTranslationJobs operation in TranslationInspectionsApi.
+ * @export
+ * @interface TranslationInspectionsApiGetQueuedTranslationJobsRequest
+ */
+export interface TranslationInspectionsApiGetQueuedTranslationJobsRequest {
+  /**
+   * The cursor for the next page of items.
+   * @type {string}
+   * @memberof TranslationInspectionsApiGetQueuedTranslationJobs
+   */
+  readonly pageCursor?: string;
+
+  /**
+   * The number of items to return.
+   * @type {number}
+   * @memberof TranslationInspectionsApiGetQueuedTranslationJobs
+   */
+  readonly pageSize?: number;
+
+  /**
+   * Status to filter on.
+   * @type {string}
+   * @memberof TranslationInspectionsApiGetQueuedTranslationJobs
+   */
+  readonly filterStatus?: string;
 }
 
 /**
@@ -18678,9 +18824,10 @@ export class TranslationInspectionsApi extends BaseAPI {
   }
 
   /**
-   * Get a `queued-translation`. The response is either the status if `running` or `error` or, upon completion, redirects to the created `part-revision`. Once created, create scenes via the createScene API. For details, see our [Render static scenes](https://developer.vertexvis.com/docs/guides/render-static-scenes) guide.
+   * This has been deprecated and replaced by **queued-translation-jobs/{id}** - Get a `queued-translation`. The response is either the status if `running` or `error` or, upon completion, redirects to the created `part-revision`. Once created, create scenes via the createScene API. For details, see our [Render static scenes](https://developer.vertexvis.com/docs/guides/render-static-scenes) guide.
    * @param {TranslationInspectionsApiGetQueuedTranslationRequest} requestParameters Request parameters.
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof TranslationInspectionsApi
    */
@@ -18710,9 +18857,31 @@ export class TranslationInspectionsApi extends BaseAPI {
   }
 
   /**
-   * Get `queued-translation`s.
+   * Get all current translation jobs in progress.
+   * @param {TranslationInspectionsApiGetQueuedTranslationJobsRequest} requestParameters Request parameters.
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof TranslationInspectionsApi
+   */
+  public getQueuedTranslationJobs(
+    requestParameters: TranslationInspectionsApiGetQueuedTranslationJobsRequest = {},
+    options?: AxiosRequestConfig
+  ) {
+    return TranslationInspectionsApiFp(this.configuration)
+      .getQueuedTranslationJobs(
+        requestParameters.pageCursor,
+        requestParameters.pageSize,
+        requestParameters.filterStatus,
+        options
+      )
+      .then((request) => request(this.axios, this.basePath));
+  }
+
+  /**
+   * This has been deprecated and replaced by **queued-translation-jobs** - Get `queued-translation`s.
    * @param {TranslationInspectionsApiGetQueuedTranslationsRequest} requestParameters Request parameters.
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof TranslationInspectionsApi
    */

--- a/client/helpers/files.ts
+++ b/client/helpers/files.ts
@@ -1,3 +1,5 @@
+import { ReadStream } from 'fs';
+
 import {
   BaseReq,
   DeleteReq,
@@ -13,7 +15,7 @@ export interface UploadFileReq extends BaseReq {
   readonly createFileReq: CreateFileRequest;
 
   /** File data. */
-  readonly fileData: Buffer;
+  readonly fileData: Buffer | ReadStream;
 }
 
 /**

--- a/client/helpers/parts.ts
+++ b/client/helpers/parts.ts
@@ -1,4 +1,5 @@
 import { AxiosResponse } from 'axios';
+import { ReadStream } from 'fs';
 
 import {
   CreateFileRequest,
@@ -39,7 +40,7 @@ export interface CreatePartFromFileReq extends BaseReq {
   readonly createPartReq: (fileId: string) => CreatePartRequest;
 
   /** File data. */
-  readonly fileData: Buffer;
+  readonly fileData: Buffer | ReadStream;
 
   /** {@link Polling} */
   readonly polling?: Polling;

--- a/client/version.ts
+++ b/client/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.21.2';
+export const version = '0.21.3';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertexvis/api-client-node",
-  "version": "0.21.2",
+  "version": "0.21.3",
   "description": "The Vertex REST API client for Node.js.",
   "license": "MIT",
   "author": "Vertex Developers <support@vertexvis.com> (https://developer.vertexvis.com)",

--- a/spec.yml
+++ b/spec.yml
@@ -4284,14 +4284,13 @@ paths:
           style: form
         - description:
             Comma-separated list of fields to return in response. An empty
-            value returns no fields. `sceneItemCount` and `metadata` are only returned
-            if explicitly requested.
+            value returns no fields. `metadata` is only returned if explicitly requested.
           explode: true
           in: query
           name: fields[scene]
           required: false
           schema:
-            example: camera,state,created,suppliedId,name,treeEnabled,modified,up,sceneItemCount,metadata
+            example: camera,state,created,suppliedId,name,treeEnabled,modified,up,metadata
             type: string
           style: form
         - description: |
@@ -4303,6 +4302,7 @@ paths:
           schema:
             additionalProperties:
               type: string
+            example: filter[metadata][key1]=test
             type: object
           style: form
       responses:
@@ -5454,76 +5454,10 @@ paths:
         - OAuth2: []
       tags:
         - translation-inspections
-  /queued-translation-jobs/{id}:
+  /queued-translation-jobs:
     get:
-      description:
-        Get a `queued-translation-job`. The response is either the status
-        if `running` or `error` or, upon completion, the `part-revision` that was
-        created. Once created, create scenes via the createScene API. For details,
-        see our [Render static scenes](https://developer.vertexvis.com/docs/guides/render-static-scenes)
-        guide.
-      operationId: getQueuedTranslationJob
-      parameters:
-        - description: The `queued-translation` ID.
-          explode: false
-          in: path
-          name: id
-          required: true
-          schema:
-            $ref: '#/components/schemas/Uuid'
-          style: simple
-      responses:
-        '200':
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/QueuedTranslationJob'
-          description: OK
-        '301':
-          description: Moved Permanently
-        '401':
-          content:
-            application/vnd.api+json:
-              example:
-                errors:
-                  - status: '401'
-                    code: Unauthorized
-                    title: Invalid or missing credentials.
-              schema:
-                $ref: '#/components/schemas/Failure'
-          description: Unauthorized
-        '404':
-          content:
-            application/vnd.api+json:
-              example:
-                errors:
-                  - status: '404'
-                    code: NotFound
-                    title: The requested resource was not found.
-              schema:
-                $ref: '#/components/schemas/Failure'
-          description: Not Found
-        '415':
-          content:
-            application/vnd.api+json:
-              example:
-                errors:
-                  - status: '415'
-                    code: UnsupportedMediaType
-                    title:
-                      The provided media type is not supported. Update the Content-Type
-                      header to application/vnd.api+json and try again.
-              schema:
-                $ref: '#/components/schemas/Failure'
-          description: Unsupported Media Type
-      security:
-        - OAuth2: []
-      tags:
-        - translation-inspections
-  /queued-translations:
-    get:
-      description: Get `queued-translation`s.
-      operationId: getQueuedTranslations
+      description: Get all current translation jobs in progress.
+      operationId: getQueuedTranslationJobs
       parameters:
         - description: The cursor for the next page of items.
           explode: true
@@ -5602,11 +5536,166 @@ paths:
         - OAuth2: []
       tags:
         - translation-inspections
-  /queued-translations/{id}:
+  /queued-translation-jobs/{id}:
     get:
       description:
-        Get a `queued-translation`. The response is either the status if
-        `running` or `error` or, upon completion, redirects to the created `part-revision`.
+        Get a `queued-translation-job`. The response is either the status
+        if `running` or `error` or, upon completion, the `part-revision` that was
+        created. Once created, create scenes via the createScene API. For details,
+        see our [Render static scenes](https://developer.vertexvis.com/docs/guides/render-static-scenes)
+        guide.
+      operationId: getQueuedTranslationJob
+      parameters:
+        - description: The `queued-translation` ID.
+          explode: false
+          in: path
+          name: id
+          required: true
+          schema:
+            $ref: '#/components/schemas/Uuid'
+          style: simple
+      responses:
+        '200':
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/QueuedTranslationJob'
+          description: OK
+        '301':
+          description: Moved Permanently
+        '401':
+          content:
+            application/vnd.api+json:
+              example:
+                errors:
+                  - status: '401'
+                    code: Unauthorized
+                    title: Invalid or missing credentials.
+              schema:
+                $ref: '#/components/schemas/Failure'
+          description: Unauthorized
+        '404':
+          content:
+            application/vnd.api+json:
+              example:
+                errors:
+                  - status: '404'
+                    code: NotFound
+                    title: The requested resource was not found.
+              schema:
+                $ref: '#/components/schemas/Failure'
+          description: Not Found
+        '415':
+          content:
+            application/vnd.api+json:
+              example:
+                errors:
+                  - status: '415'
+                    code: UnsupportedMediaType
+                    title:
+                      The provided media type is not supported. Update the Content-Type
+                      header to application/vnd.api+json and try again.
+              schema:
+                $ref: '#/components/schemas/Failure'
+          description: Unsupported Media Type
+      security:
+        - OAuth2: []
+      tags:
+        - translation-inspections
+  /queued-translations:
+    get:
+      deprecated: true
+      description:
+        This has been deprecated and replaced by **queued-translation-jobs**
+        - Get `queued-translation`s.
+      operationId: getQueuedTranslations
+      parameters:
+        - description: The cursor for the next page of items.
+          explode: true
+          in: query
+          name: page[cursor]
+          required: false
+          schema:
+            example: cHJkMDVFR2RLag==
+            type: string
+          style: form
+        - description: The number of items to return.
+          explode: true
+          in: query
+          name: page[size]
+          required: false
+          schema:
+            example: 10
+            format: int32
+            maximum: 200
+            minimum: 1
+            type: integer
+          style: form
+        - description: Status to filter on.
+          explode: true
+          in: query
+          name: filter[status]
+          required: false
+          schema:
+            example: running
+            maxLength: 1024
+            type: string
+          style: form
+      responses:
+        '200':
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/QueuedJobList'
+          description: OK
+        '301':
+          description: Moved Permanently
+        '401':
+          content:
+            application/vnd.api+json:
+              example:
+                errors:
+                  - status: '401'
+                    code: Unauthorized
+                    title: Invalid or missing credentials.
+              schema:
+                $ref: '#/components/schemas/Failure'
+          description: Unauthorized
+        '404':
+          content:
+            application/vnd.api+json:
+              example:
+                errors:
+                  - status: '404'
+                    code: NotFound
+                    title: The requested resource was not found.
+              schema:
+                $ref: '#/components/schemas/Failure'
+          description: Not Found
+        '415':
+          content:
+            application/vnd.api+json:
+              example:
+                errors:
+                  - status: '415'
+                    code: UnsupportedMediaType
+                    title:
+                      The provided media type is not supported. Update the Content-Type
+                      header to application/vnd.api+json and try again.
+              schema:
+                $ref: '#/components/schemas/Failure'
+          description: Unsupported Media Type
+      security:
+        - OAuth2: []
+      tags:
+        - translation-inspections
+  /queued-translations/{id}:
+    get:
+      deprecated: true
+      description:
+        This has been deprecated and replaced by **queued-translation-jobs/{id}**
+        - Get a `queued-translation`. The response is either the status if `running`
+        or `error` or, upon completion, redirects to the created `part-revision`.
         Once created, create scenes via the createScene API. For details, see our
         [Render static scenes](https://developer.vertexvis.com/docs/guides/render-static-scenes)
         guide.
@@ -6485,6 +6574,18 @@ components:
         example: camera,state,created,suppliedId,name,treeEnabled,modified,up,sceneItemCount,metadata
         type: string
       style: form
+    ListScenesFields:
+      description:
+        Comma-separated list of fields to return in response. An empty
+        value returns no fields. `metadata` is only returned if explicitly requested.
+      explode: true
+      in: query
+      name: fields[scene]
+      required: false
+      schema:
+        example: camera,state,created,suppliedId,name,treeEnabled,modified,up,metadata
+        type: string
+      style: form
     MetadataFilter:
       description: |
         Filter scenes that contain all the given metadata key-value pairs. Should be specified in query parameter map notation: `filter[metadata][key1]=value1&filter[metadata][key]=value2`.
@@ -6495,6 +6596,7 @@ components:
       schema:
         additionalProperties:
           type: string
+        example: filter[metadata][key1]=test
         type: object
       style: form
     SceneViewStateFields:
@@ -7486,6 +7588,21 @@ components:
       required:
         - data
       type: object
+    QueuedJobList:
+      additionalProperties: false
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/QueuedJobData'
+          type: array
+        links:
+          additionalProperties:
+            $ref: '#/components/schemas/Link'
+          type: object
+      required:
+        - data
+        - links
+      type: object
     QueuedTranslationJob:
       additionalProperties: false
       properties:
@@ -7503,21 +7620,6 @@ components:
           type: object
       required:
         - data
-      type: object
-    QueuedJobList:
-      additionalProperties: false
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/QueuedJobData'
-          type: array
-        links:
-          additionalProperties:
-            $ref: '#/components/schemas/Link'
-          type: object
-      required:
-        - data
-        - links
       type: object
     CreateExportRequest:
       additionalProperties: false


### PR DESCRIPTION
## Summary
This change adds support for clients to pass a Node `ReadStream` object in addition to a `Buffer` for create File calls. Use of `ReadStream` allows for better memory management and support for files in excess of 2GB.

Also updated to latest API spec.