### PR TITLE
[PLAT-3659] Add backoff support for queued jobs

### DIFF
--- a/client/index.ts
+++ b/client/index.ts
@@ -39,6 +39,12 @@ export interface Polling {
 
   /** Maximum number of polling attempts. */
   readonly maxAttempts: number;
+
+  /**
+   * A map of polling attempt numbers to a delay in milliseconds.
+   * Once the attempts are reach, the backoff will be added to `intervalMs`.
+   */
+  readonly backoff?: Record<number, number | undefined>;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertexvis/api-client-node",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "The Vertex REST API client for Node.js.",
   "license": "MIT",
   "author": "Vertex Developers <support@vertexvis.com> (https://developer.vertexvis.com)",


### PR DESCRIPTION
## Summary

Adds support for providing a `backoff` configuration when using helpers to poll queued jobs to allow for longer running tasks to progressively reduce the number of requests being made.

## Test Plan

- Verify that passing a `backoff` configuration when polling queued jobs properly increases the time between requests

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
