### PR TITLE
[PLAT-4707] Throw descriptive error when polling times out

### DIFF
--- a/client/helpers/queued-jobs.ts
+++ b/client/helpers/queued-jobs.ts
@@ -149,7 +149,7 @@ export async function pollQueuedJob<T>({
 }
 
 export function isPollError<T>(r: PollRes<T>): r is QueuedJob | Failure {
-  return isQueuedJobError(r) || isFailure(r);
+  return isQueuedJobError(r) || isQueuedJobRunning(r) || isFailure(r);
 }
 
 export function isBatch(obj: PollRes<Batch>): obj is Batch {
@@ -188,12 +188,21 @@ function isQueuedJobError(obj: any): obj is QueuedJob {
   return isQueuedJob(obj) && isStatusError(obj);
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
+function isQueuedJobRunning(obj: any): obj is QueuedJob {
+  return isQueuedJob(obj) && isStatusRunning(obj);
+}
+
 function isStatusComplete(job: QueuedJob): boolean {
   return job.data.attributes.status === 'complete';
 }
 
 function isStatusError(job: QueuedJob): boolean {
   return job.data.attributes.status === 'error';
+}
+
+function isStatusRunning(job: QueuedJob): boolean {
+  return job.data.attributes.status === 'running';
 }
 
 function isClientError<T>(res: PollRes<T>): boolean {


### PR DESCRIPTION
## Summary
When a job did not complete in the designated time period, we were not throwing a descriptive error message. With this PR, we will now throw an error that explicitly states that the job timed out, specifically [this error](https://github.com/Vertexvis/vertex-api-client-node/blob/5c1519b6ec96d798d33e44e5b1ff26c0ee1f7098/client/helpers/queued-jobs.ts#L164-L166).

## Test Plan
- Verify polling jobs behaves as expected
- Verify a descriptive error is thrown when a job times out

## Release Notes
None

## Possible Regressions
Polling for jobs to finish

## Dependencies
None