### PR TITLE
[PLAT-8473] Add the DocumentsApi to the VertexClient definition

### DIFF
--- a/client/version.ts
+++ b/client/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.42.0';
+export const version = '0.42.1';

--- a/client/vertex-client.ts
+++ b/client/vertex-client.ts
@@ -6,6 +6,7 @@ import {
   BatchesApi,
   CollaborationContextsApi,
   Configuration,
+  DocumentsApi,
   ExportsApi,
   FilesApi,
   GeometrySetsApi,
@@ -130,6 +131,7 @@ export class VertexClient {
   public applications: ApplicationsApi;
   public batches: BatchesApi;
   public collaborationContexts: CollaborationContextsApi;
+  public documents: DocumentsApi;
   public exports: ExportsApi;
   public files: FilesApi;
   public geometrySets: GeometrySetsApi;
@@ -178,6 +180,7 @@ export class VertexClient {
       undefined,
       axiosInst
     );
+    this.documents = new DocumentsApi(this.config, undefined, axiosInst);
     this.exports = new ExportsApi(this.config, undefined, axiosInst);
     this.files = new FilesApi(this.config, undefined, axiosInst);
     this.geometrySets = new GeometrySetsApi(this.config, undefined, axiosInst);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertexvis/api-client-node",
-  "version": "0.42.0",
+  "version": "0.42.1",
   "description": "The Vertex REST API client for Node.js.",
   "license": "MIT",
   "author": "Vertex Developers <support@vertexvis.com> (https://developer.vertexvis.com)",


### PR DESCRIPTION
## Summary

Title says it all - adding the `DocumentsApi` to the `VertexClient` to support making calls to these new endpoints.

## Test Plan

- Verify `/documents` API calls can be made using a `VertexClient`

## Release Notes

N/A

## Possible Regressions

N/A

## Dependencies

N/A
